### PR TITLE
adds a conda recipe

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: pywt
+  version: master
+
+source:
+  git_url: https://github.com/nigma/pywt.git
+  git_tag: master
+
+#build:
+#  script: python setup.py install
+
+requirements:
+  build:
+    - cython
+    - python
+    - numpy
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - pywt
+
+about:
+  license: MIT
+  home: http://www.pybytes.com/pywavelets/
+  summary: PyWavelets, wavelet transform module


### PR DESCRIPTION
Just wanted to offer a conda recipe to build redistributable binary packages with the conda package manager. To create the actual package, one would install conda, then install conda-build, and finally run "conda build conda.recipe".
